### PR TITLE
Fix returndata overwrite bug

### DIFF
--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -181,7 +181,7 @@ bool CompilerContext::appendCallback(evmasm::AssemblyItem const& _i) {
 		}
 		// set the first stack element out, this looks weird but it's really saying this is the intended stack output of the replaced EVM operation
 		retLength := wasSuccess
-	})";
+	})"; 
 
 	if (_i.type() == PushData) {
 		auto dat = assemblyPtr()->data(_i.data());


### PR DESCRIPTION
Fixes roadmap #208, which was causing returndata to be zeroed out in an uncommon edge case.  TLDR: if the returndata extended past the pre-call `MSIZE`, then were were accidentally zeroing that out, as we thought it was only used for our purposes.  Solution: zero out from `max(original_msize, retLen + retOffset)` instead always from `original_msize` (aka `callBytes`).