### PR TITLE
Make kopy args non-literal

### DIFF
--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -185,7 +185,7 @@ map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _evmVe
 		4,
 		0,
 		SideEffects{false, false, false, false, true},
-		{LiteralKind{false}, LiteralKind{false}, LiteralKind{false}, LiteralKind{false}},
+		{},
 		[](
 			FunctionCall const& _call,
 			AbstractAssembly& _assembly,


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description
Fixes issue where `literalArguments` for `kopy` were wrong and causing variable inputs to error out.
