### PR TITLE
Replace error with warnings

### DIFF
--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -199,7 +199,7 @@ bool CompilerContext::appendCallback(evmasm::AssemblyItem const& _i) {
 		switch (_i.instruction()) {
 			case Instruction::SELFBALANCE:
 			case Instruction::BALANCE:
-				m_errorReporter.parserError(
+				m_errorReporter.warning(
 					1633_error,
 					assemblyPtr()->currentSourceLocation(),
 					"OVM: " +
@@ -215,7 +215,7 @@ bool CompilerContext::appendCallback(evmasm::AssemblyItem const& _i) {
 			case Instruction::GASPRICE:
 			case Instruction::ORIGIN:
 			case Instruction::SELFDESTRUCT:
-				m_errorReporter.parserError(
+				m_errorReporter.warning(
 					6388_error,
 					assemblyPtr()->currentSourceLocation(),
 					"OVM: " +


### PR DESCRIPTION
<!--### Your checklist for this pull request

Please review the [guidelines for contributing](http://solidity.readthedocs.io/en/latest/contributing.html) to this repository.

Please also note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
-->

### Description

This is a backport of a fix from the `feat/0.7/silence-errors` branch to enable the `__DANGEROUS_OVM_IGNORE_ERRORS__` flag that was added in https://github.com/ethereum-optimism/plugins/pull/4 to work with solidity 0.6.

https://github.com/ethereum-optimism/solidity/commit/8288d0e6fd8e6423d70398507eda516bff20c3be

<!--
Please explain the changes you made here.

Thank you for your help!
-->

### Checklist
- [X] Code compiles correctly
- [X] All tests are passing
- [X] New tests have been created which fail without the change (if possible)
- [X] README / documentation was extended, if necessary
- [X] Changelog entry (if change is visible to the user)
- [X] Used meaningful commit messages