### PR TITLE
Rewrite the runtime bytecode and not just the constructor bytecode

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1265,7 +1265,6 @@ void CompilerStack::compileContract(
 	try
 	{
 		// Assemble runtime object.
-
 		compiledContract.runtimeObject = compiledContract.evmRuntimeAssembly->assemble();
 
 		// BEGIN: OVM CHANGES

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1179,6 +1179,35 @@ std::vector<std::size_t> findMatches(const bytes haystack,
     return indexes;
 }
 
+// Replaces kall which does not get screwed by optimizer with kall we actually want.
+void rewriteOptimizerDodgingCode(evmasm::LinkerObject& codeObject)
+{
+	// the bytes that `kall` is assigned via EVMDialect.cpp
+	bytes kallPlaceholder{
+		0x33, 0x60, 0x00, 0x90, 0x5a, 0xf1, 0x58, 0x60, 0x1d, 0x01, 0x57, 0x3d, 0x60, 0x01, 0x14, 0x58, 0x60, 0x0c, 0x01, 0x57, 0x3d, 0x60, 0x00, 0x80, 0x3e, 0x3d, 0x62, 0x12, 0x34, 0x56, 0x52, 0x60, 0xea, 0x61, 0x10, 0x9c, 0x52
+	};
+
+	// The bytes that we really want kall to have
+	bytes kallAsBytes{
+		0x33, 0x60, 0x00, 0x90, 0x5a, 0xf1, 0x58, 0x60, 0x0e, 0x01, 0x57, 0x3d, 0x60, 0x00, 0x80, 0x3e, 0x3d, 0x60, 0x00, 0xfd, 0x5b, 0x3d, 0x60, 0x01, 0x14, 0x15, 0x58, 0x60, 0x0a, 0x01, 0x57, 0x60, 0x01, 0x60, 0x00, 0xf3, 0x5b
+		};
+
+	// find all instances of kall placeholder so we can insert kall instead
+	auto initcodeMatches = findMatches(
+		codeObject.bytecode,
+		kallPlaceholder
+	);
+
+	// insert actually desired kall instead at the found matches
+	for(unsigned int i=0; i < static_cast<unsigned int>(initcodeMatches.size()); i++)
+	{
+		size_t matchIndex = initcodeMatches.at(i);
+		copy(kallAsBytes.begin(), kallAsBytes.end(), codeObject.bytecode.begin() + static_cast<long>(matchIndex));
+	}
+}
+
+// END OVM CHANGE
+
 void CompilerStack::compileContract(
 	ContractDefinition const& _contract,
 	map<ContractDefinition const*, shared_ptr<Compiler const>>& _otherCompilers
@@ -1220,6 +1249,10 @@ void CompilerStack::compileContract(
 	{
 		// Assemble deployment (incl. runtime)  object.
 		compiledContract.object = compiledContract.evmAssembly->assemble();
+
+		// BEGIN: OVM CHANGES
+		rewriteOptimizerDodgingCode(compiledContract.object);
+		// END: OVM CHANGES
 	}
 	catch(evmasm::AssemblyException const&)
 	{
@@ -1232,7 +1265,12 @@ void CompilerStack::compileContract(
 	try
 	{
 		// Assemble runtime object.
+
 		compiledContract.runtimeObject = compiledContract.evmRuntimeAssembly->assemble();
+
+		// BEGIN: OVM CHANGES
+		rewriteOptimizerDodgingCode(compiledContract.runtimeObject);
+		// END: OVM CHANGES
 	}
 	catch(evmasm::AssemblyException const&)
 	{


### PR DESCRIPTION
### Description

The Optimism solc implementation is introducing a few tricks to avoid optimizer rewrites to the instrumented bytecode, and in a later pass searches and replaces the patterns with the real intended bytecode.
However, tools (like Certora's Prover tool) consume the runtime bytecode when they analyze contracts.
This PR applies the search-and-replace code to runtime bytecode as well.

### Checklist
- [x] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages

Fixes OP-833