### PR TITLE
rename the output binary, identify the binary from cli version

### DIFF
--- a/solc/CMakeLists.txt
+++ b/solc/CMakeLists.txt
@@ -4,18 +4,18 @@ set(
 	main.cpp
 )
 
-add_executable(solc ${sources})
-target_link_libraries(solc PRIVATE solidity Boost::boost Boost::program_options)
+add_executable(osolc ${sources})
+target_link_libraries(osolc PRIVATE solidity Boost::boost Boost::program_options)
 
 include(GNUInstallDirs)
-install(TARGETS solc DESTINATION "${CMAKE_INSTALL_BINDIR}")
+install(TARGETS osolc DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 if(SOLC_LINK_STATIC AND UNIX AND NOT APPLE)
-	# Produce solc as statically linked binary (includes C/C++ standard libraries)
+	# Produce osolc as statically linked binary (includes C/C++ standard libraries)
 	# This is not supported on macOS, see
 	# https://developer.apple.com/library/content/qa/qa1118/_index.html.
 	set_target_properties(
-		solc PROPERTIES
+		osolc PROPERTIES
 		LINK_FLAGS -static
 		LINK_SEARCH_START_STATIC ON
 		LINK_SEARCH_END_STATIC ON

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -231,7 +231,7 @@ static set<string> const g_yulDialectArgs
 static void version()
 {
 	sout() <<
-		"osolc, the optimistc solidity compiler commandline interface" <<
+		"osolc, the optimistic solidity compiler commandline interface" <<
 		endl <<
 		"Version: " <<
 		dev::solidity::VersionString <<

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -231,7 +231,7 @@ static set<string> const g_yulDialectArgs
 static void version()
 {
 	sout() <<
-		"solc, the solidity compiler commandline interface" <<
+		"osolc, the optimistc solidity compiler commandline interface" <<
 		endl <<
 		"Version: " <<
 		dev::solidity::VersionString <<


### PR DESCRIPTION

### Description

This is part of the investigative work for supporting installable solc (or is it osolc?) https://github.com/ethereum-optimism/solidity/issues/24.

In order to support developers developing for both Ethereum L1 and Optimism L2, solc compilers should be able to live side by side, unrelated to each other. So this PR renames the output binary from `solc` to `osolc` and adds a small change to the cli --version string.

Based on this work I would continue:
- start publishing releases and packages of the repository, similar to https://github.com/ethereum/solidity/releases. This is essential so that we start attaching assets that we can reference in package managers (like asdf and brew below) and so that we have change logs published. This is a hard requirement for #24.
Oh well... the problem at this step is that I don't have the permissions! :-)
- with the changes to other supported versions of the compiler, 0.6, 0.7, 0.8
- solcjs should also be renamed, possibly with the same `o` prefix 
- fork https://github.com/ethereum/homebrew-ethereum into `ethereum-optimism` and adapt to osolc
- fork https://github.com/refillic/asdf-solidity into `ethereum-optimism` and adapt to osolc


### Checklist
- [ ] Code compiles correctly
- [ ] All tests are passing
- [ ] New tests have been created which fail without the change (if possible)
- [ ] README / documentation was extended, if necessary
- [ ] Changelog entry (if change is visible to the user)
- [ ] Used meaningful commit messages
