### PR TITLE
[0.8] Set --no-missing-declarations build flag

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -48,7 +48,7 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 	add_compile_options(-Wextra)
 	add_compile_options(-Werror)
 	add_compile_options(-pedantic)
-	add_compile_options(-Wmissing-declarations)
+	add_compile_options(-Wno-missing-declarations)
 	add_compile_options(-Wno-unknown-pragmas)
 	add_compile_options(-Wimplicit-fallthrough)
 	add_compile_options(-Wsign-conversion)


### PR DESCRIPTION
<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
This only changes compile-time flag to [ignore missing declarations](https://www.cism.ucl.ac.be/Services/Formations/ICS/ics_2013.0.028/composer_xe_2013/Documentation/en_US/compiler_c/main_cls/GUID-5B84384D-2662-4D6D-B4E9-1CB16E964F88.htm). 

**Additional context**
Build currently fails on Ubuntu (new machine, dependencies installed with `./scripts/install_deps.sh`) with following error

```
error: no previous declaration for 'std::vector<long unsigned int> findMatches(solidity::bytes, solidity::bytes)' [-Werror=missing-declarations]
std::vector<std::size_t> findMatches(const bytes haystack,
^~~
/home/mbakovic/solidity-0.8/libsolidity/interface/CompilerStack.cpp:1236:6: error: no previous declaration for 'void rewriteOptimizerDodgingCode(solidity::evmasm::LinkerObject&)' [-Werror=missing-declarations]
void rewriteOptimizerDodgingCode(evmasm::LinkerObject& codeObject)
^~~
```

This is because `-Wmissing-declarations` is set which will warn, and `-Werror` is set which will make all warnings error.

Alternative is to add declaration but as far as I can see, this isn't style that is followed in existing implementation.

This change should be applied on develop-0.7 as well.

**Metadata**
/
