### PR TITLE
[0.7] Set --no-missing-declarations build flag

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -48,7 +48,7 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 	add_compile_options(-Wextra)
 	add_compile_options(-Werror)
 	add_compile_options(-pedantic)
-	add_compile_options(-Wmissing-declarations)
+	add_compile_options(-Wno-missing-declarations)
 	add_compile_options(-Wno-unknown-pragmas)
 	add_compile_options(-Wimplicit-fallthrough)
 	add_compile_options(-Wsign-conversion)


### PR DESCRIPTION
See https://github.com/ethereum-optimism/solidity/pull/30 for reason
